### PR TITLE
Potential fix for code scanning alert no. 6: Use of weak cryptographic key

### DIFF
--- a/Programs/P73_SimplePythonEncryption.py
+++ b/Programs/P73_SimplePythonEncryption.py
@@ -13,7 +13,7 @@ from Crypto import Random
 randomGenerator = Random.new().read
 # Generating a private key and a public key
 # key stores both the keys
-key = RSA.generate(1024, randomGenerator) # 1024 is the size of the key in bits
+key = RSA.generate(2048, randomGenerator) # 2048 is the size of the key in bits
 print(key)                                # Prints private key
 print(key.publickey())                    # Prints public key
 


### PR DESCRIPTION
Potential fix for [https://github.com/ShashikantSingh09/python-progrrames/security/code-scanning/6](https://github.com/ShashikantSingh09/python-progrrames/security/code-scanning/6)

To fix the issue, the RSA key size should be increased from 1024 bits to at least 2048 bits, as recommended by current cryptographic standards. This change ensures that the encryption is secure against brute-force attacks. The modification involves updating the `RSA.generate` function call on line 16 to use a key size of 2048 bits. No additional changes are required to maintain the functionality of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
